### PR TITLE
433 MHz testing additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This library is based on code examples from Silicon Labs [Wireless Development S
 
 **Beta release, everything has not been tested yet!**
 
-> This library may not be directly compatible with any board implementing Si4455 chip! Currently it was only tested with ZETA-868-SO module from RF Solutions.
+> This library may not be directly compatible with any board implementing Si4455 chip! Currently it was only tested with the ZETA-868-SO and ZETA-433-SO modules from RF Solutions.
 
 ZETA module datasheet: <https://www.rfsolutions.co.uk/downloads/1456219226DS-ZETA.pdf>
 
@@ -53,6 +53,19 @@ To receive variable length packets, listening is done with a length of zero (han
 
 
 ## Usage
+
+### Including the SPI header file 
+
+It has been reported that on the latest Arduino IDE you have to explicitly add the following before you include the ZetaRF.h file, even though 
+the SPI.h file is included by the ZetaRF.h file itself. Not doing this will generate many compiler warnings about a 'missing' SPI.h file.
+
+  #include <SPI.h>
+
+### 868 MHz or 433 MHz operation
+
+By default this library configures the Zeta for 868 MHz operation. If you instead have a 433MHz module, then add this before including the ZetaRF.h file:-
+
+  #define FREQ_433 1
 
 ### Send data
 
@@ -132,6 +145,8 @@ ZETA Pin #|ZETA Module|Arduino|Description
 10        |SDI        |MOSI   |Zeta SPI In to Arduino SPI Out
 11        |SDO        |MISO   |Zeta SPI Out to Arduino SPI In
 12        |nSEL       |CS     |Chip Select
+
+(**Note** - On the Arduino Pro Mini it has been reported that the Zeta SDI pin needs connecting to MISO (pin 11), and the SDO to MOSI (pin 12) - the opposite order to that described in the above table.)
 
 (**Note** - Possible improvement: a GPIO could be used for CTS instead of polling a register)
 

--- a/ZetaRF.cpp
+++ b/ZetaRF.cpp
@@ -13,10 +13,18 @@
 #include "ZetaRF.h"
 
 #ifdef VARIABLE_LENGTH_ON
+#ifdef FREQ_433
+    #include "configs/radio_config_vl_crc_pre10_sync4_pay8_433mhz.h"
+#else
     #include "configs/radio_config_vl_crc_pre10_sync4_pay8.h"
+#endif
     #warning Using variable length packets
 #else
+#ifdef FREQ_433
+    #include "configs/radio_config_fixed_crc_pre10_sync4_pay8_433mhz.h"
+#else
     #include "configs/radio_config_fixed_crc_pre10_sync4_pay8.h"
+#endif
     #warning Using fixed length packets
 #endif
 

--- a/configs/radio_config_fixed_crc_pre10_sync4_pay8_433mhz.h
+++ b/configs/radio_config_fixed_crc_pre10_sync4_pay8_433mhz.h
@@ -1,0 +1,210 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si4455 Rev.: B1
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+ // Crys_freq(Hz): 30000000    Crys_tol(ppm): 30    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0
+ // MOD_type: 2    Rsymb(sps): 2400    Fdev(Hz): 30000    RXBW(Hz): 114000    Manchester: 1    AFC_en: 1    Rsymb_error: 0.0    Chip-Version: 2
+ // RF Freq.(MHz): 433    API_TC: 28    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 0
+ //
+ // # WB filter 1 (BW = 114.46 kHz);  NB-filter 1 (BW = 114.46 kHz)
+ 
+ //
+ // Modulation index: 25
+ */
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x08
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+ // Command:                  RF_POWER_UP
+ // Description:              Command to power-up the device and select the operational mode and functionality.
+ */
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+ // Set properties:           RF_INT_CTL_ENABLE_2
+ // Number of properties:     2
+ // Group ID:                 0x01
+ // Start ID:                 0x00
+ // Default values:           0x04, 0x00,
+ // Descriptions:
+ //   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+ //   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+ */
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x05, 0x38
+
+/*
+ // Set properties:           RF_INT_CTL_CHIP_ENABLE_1
+ // Number of properties:     1
+ // Group ID:                 0x01
+ // Start ID:                 0x03
+ // Default values:           0x04,
+ // Descriptions:
+ //   INT_CTL_CHIP_ENABLE - Enable individual interrupt sources within the Chip Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+ */
+#define RF_INT_CTL_CHIP_ENABLE_1 0x11, 0x01, 0x01, 0x03, 0x6C
+
+/*
+ // Set properties:           RF_FRR_CTL_A_MODE_4
+ // Number of properties:     4
+ // Group ID:                 0x02
+ // Start ID:                 0x00
+ // Default values:           0x01, 0x02, 0x09, 0x00,
+ // Descriptions:
+ //   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+ //   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+ //   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+ //   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+ */
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x09, 0x04, 0x06, 0x08
+
+/*
+ // Set properties:           RF_EZCONFIG_XO_TUNE_1
+ // Number of properties:     1
+ // Group ID:                 0x24
+ // Start ID:                 0x03
+ // Default values:           0x40,
+ // Descriptions:
+ //   EZCONFIG_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+ */
+#define RF_EZCONFIG_XO_TUNE_1 0x11, 0x24, 0x01, 0x03, 0x52
+
+/*
+ // Command:                  RF_WRITE_TX_FIFO
+ // Description:              Writes data byte(s) to the TX FIFO.
+ */
+#define RF_WRITE_TX_FIFO 0x66, 0x82, 0x0A, 0xB3, 0x00, 0x23, 0xF5, 0xF4, 0x28, 0x36, 0x40, 0x11, 0xFB, 0xBE, 0x63, 0xA2, 0x9D, 0x5A, 0x92, 0x9D, \
+0xCD, 0xD7, 0x9E, 0xD1, 0xC8, 0x98, 0x64, 0x24, 0x30, 0x98, 0xA7, 0xAB, 0x0D, 0x27, 0xF7, 0x31, 0x3D, 0x73, 0x89, 0xF2, \
+0x73, 0xFB, 0x23, 0xE5, 0x3E, 0xC2, 0xEF, 0xAF, 0x28, 0xDD, 0x33, 0xC8, 0x8A, 0xE5, 0xD8, 0xEE, 0x45, 0x60, 0x28, 0x14, \
+0xCF, 0x24, 0x38, 0x7B, 0xD9, 0xAE, 0x32, 0x69, 0x8F, 0x55, 0xD9, 0x20, 0xB9, 0xD3, 0x5E, 0xCE, 0x43, 0x2F, 0x90, 0xA8, \
+0xBD, 0xCC, 0x2B, 0xD5, 0x80, 0x49, 0xB8, 0x81, 0x32, 0x5E, 0x4E, 0xB8, 0xD2, 0x89, 0x16, 0x82, 0x9B, 0xC6, 0xC0, 0x9D, \
+0x7B, 0xF6, 0x66, 0x9C, 0x4B, 0x1D, 0x0D, 0x35, 0x32, 0x15, 0x4B, 0xE8, 0xA8, 0x9A
+
+/*
+ // Command:                  RF_NOP
+ // Description:              No Operation command.
+ */
+#define RF_NOP 0x00
+
+/*
+ // Command:                  RF_WRITE_TX_FIFO_1
+ // Description:              Writes data byte(s) to the TX FIFO.
+ */
+#define RF_WRITE_TX_FIFO_1 0x66, 0xE4, 0x42, 0x72, 0xFA, 0x21, 0xA2, 0xE5, 0xB1, 0x0E, 0xB1, 0xD3, 0xCA, 0x56, 0x7D, 0x3B, 0xF0, 0x0A, 0x37, 0x49, \
+0xF0, 0x74, 0x3D, 0xF3, 0x76, 0x2C, 0x9F, 0x28, 0x6A, 0x90, 0x21, 0xBB, 0x6B, 0xAD, 0xFA, 0xB8, 0x46, 0x4E, 0x1B, 0x4E, \
+0xF6, 0x51, 0xF2, 0xE0, 0x94, 0x3F, 0xD4, 0xD5, 0xC4, 0x57, 0xE8, 0x86, 0x91, 0xED, 0x2C, 0xEA, 0x6C, 0x13, 0x29, 0x3F, \
+0x83, 0x89, 0x1E, 0xD4, 0x4B, 0x45, 0x05, 0x25, 0x32, 0x73, 0xA4, 0x5A, 0xF4, 0x59, 0xCA, 0xFA, 0x5D, 0xD9, 0x3A, 0xE6, \
+0x39, 0xC6, 0x26, 0xE3, 0x6F, 0x26, 0x94, 0x06, 0x98, 0x46, 0xEF, 0x4D, 0x50, 0x16, 0xF9, 0xCC, 0x25, 0x72, 0x95, 0xFE, \
+0x81, 0x0C, 0x00, 0x8D, 0xD0, 0xC6, 0x53, 0xD2, 0xFB, 0xF7, 0x00, 0x94
+
+/*
+ // Command:                  RF_EZCONFIG_CHECK
+ // Description:              Validates the EZConfig array was written correctly.
+ */
+#define RF_EZCONFIG_CHECK 0x19, 0x16, 0x3C
+
+/*
+ // Command:                  RF_GPIO_PIN_CFG
+ // Description:              Configures the GPIO pins.
+ */
+#define RF_GPIO_PIN_CFG 0x13, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00
+
+
+// AUTOMATICALLY GENERATED CODE!
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+0x07, RF_POWER_UP, \
+0x06, RF_INT_CTL_ENABLE_2, \
+0x05, RF_INT_CTL_CHIP_ENABLE_1, \
+0x08, RF_FRR_CTL_A_MODE_4, \
+0x05, RF_EZCONFIG_XO_TUNE_1, \
+0x72, RF_WRITE_TX_FIFO, \
+0x01, RF_NOP, \
+0x70, RF_WRITE_TX_FIFO_1, \
+0x03, RF_EZCONFIG_CHECK, \
+0x08, RF_GPIO_PIN_CFG, \
+0x00 \
+}
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT  		           {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+Radio_Configuration_Data_Array,                            \
+RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,      \
+RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                    \
+}
+
+#endif /* RADIO_CONFIG_H_ */

--- a/configs/radio_config_vl_crc_pre10_sync4_pay8_433mhz.h
+++ b/configs/radio_config_vl_crc_pre10_sync4_pay8_433mhz.h
@@ -1,0 +1,209 @@
+/*! @file radio_config.h
+ * @brief This file contains the automatically generated
+ * configurations.
+ *
+ * @n WDS GUI Version: 3.2.11.0
+ * @n Device: Si4455 Rev.: B1                                 
+ *
+ * @b COPYRIGHT
+ * @n Silicon Laboratories Confidential
+ * @n Copyright 2017 Silicon Laboratories, Inc.
+ * @n http://www.silabs.com
+ */
+
+#ifndef RADIO_CONFIG_H_
+#define RADIO_CONFIG_H_
+
+// USER DEFINED PARAMETERS
+// Define your own parameters here
+
+// INPUT DATA
+/*
+// Crys_freq(Hz): 30000000    Crys_tol(ppm): 30    IF_mode: 2    High_perf_Ch_Fil: 1    OSRtune: 0    Ch_Fil_Bw_AFC: 0    ANT_DIV: 0    PM_pattern: 0    
+// MOD_type: 2    Rsymb(sps): 128000    Fdev(Hz): 70000    RXBW(Hz): 305000    Manchester: 1    AFC_en: 1    Rsymb_error: 0.0    Chip-Version: 2    
+// RF Freq.(MHz): 433    API_TC: 28    fhst: 250000    inputBW: 0    BERT: 0    RAW_dout: 0    D_source: 0    Hi_pfm_div: 0    
+// 
+// # WB filter 2 (BW = 274.83 kHz);  NB-filter 2 (BW = 274.83 kHz) 
+// 
+// Modulation index: 1
+*/
+
+
+// CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH               0x09
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP        0x03
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET       0xF000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD					   {0x08, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5, 0xC5}
+
+
+// CONFIGURATION COMMANDS
+
+/*
+// Command:                  RF_POWER_UP
+// Description:              Command to power-up the device and select the operational mode and functionality.
+*/
+#define RF_POWER_UP 0x02, 0x01, 0x00, 0x01, 0xC9, 0xC3, 0x80
+
+/*
+// Set properties:           RF_INT_CTL_ENABLE_2
+// Number of properties:     2
+// Group ID:                 0x01
+// Start ID:                 0x00
+// Default values:           0x04, 0x00, 
+// Descriptions:
+//   INT_CTL_ENABLE - This property provides for global enabling of the three interrupt groups (Chip, Modem and Packet Handler) in order to generate HW interrupts at the NIRQ pin.
+//   INT_CTL_PH_ENABLE - Enable individual interrupt sources within the Packet Handler Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_ENABLE_2 0x11, 0x01, 0x02, 0x00, 0x05, 0x38
+
+/*
+// Set properties:           RF_INT_CTL_CHIP_ENABLE_1
+// Number of properties:     1
+// Group ID:                 0x01
+// Start ID:                 0x03
+// Default values:           0x04, 
+// Descriptions:
+//   INT_CTL_CHIP_ENABLE - Enable individual interrupt sources within the Chip Interrupt Group to generate a HW interrupt on the NIRQ output pin.
+*/
+#define RF_INT_CTL_CHIP_ENABLE_1 0x11, 0x01, 0x01, 0x03, 0x6C
+
+/*
+// Set properties:           RF_FRR_CTL_A_MODE_4
+// Number of properties:     4
+// Group ID:                 0x02
+// Start ID:                 0x00
+// Default values:           0x01, 0x02, 0x09, 0x00, 
+// Descriptions:
+//   FRR_CTL_A_MODE - Fast Response Register A Configuration.
+//   FRR_CTL_B_MODE - Fast Response Register B Configuration.
+//   FRR_CTL_C_MODE - Fast Response Register C Configuration.
+//   FRR_CTL_D_MODE - Fast Response Register D Configuration.
+*/
+#define RF_FRR_CTL_A_MODE_4 0x11, 0x02, 0x04, 0x00, 0x09, 0x04, 0x06, 0x08
+
+/*
+// Set properties:           RF_EZCONFIG_XO_TUNE_1
+// Number of properties:     1
+// Group ID:                 0x24
+// Start ID:                 0x03
+// Default values:           0x40, 
+// Descriptions:
+//   EZCONFIG_XO_TUNE - Configure the internal capacitor frequency tuning bank for the crystal oscillator.
+*/
+#define RF_EZCONFIG_XO_TUNE_1 0x11, 0x24, 0x01, 0x03, 0x52
+
+/*
+// Command:                  RF_WRITE_TX_FIFO
+// Description:              Writes data byte(s) to the TX FIFO.
+*/
+#define RF_WRITE_TX_FIFO 0x66, 0xA2, 0xC9, 0x3A, 0xB9, 0x8F, 0x82, 0x2D, 0xC9, 0xA6, 0x6C, 0x9F, 0x3E, 0x0D, 0x58, 0x9E, 0x8C, 0xB7, 0x93, 0xE3, \
+0x1F, 0x9A, 0x22, 0x7B, 0xBF, 0x55, 0xFD, 0xD1, 0xC1, 0xA8, 0x5C, 0x14, 0x13, 0xED, 0x06, 0xAE, 0x53, 0x79, 0xED, 0x53, \
+0x4B, 0xAE, 0x12, 0xA3, 0x29, 0x6A, 0xA3, 0x04, 0x67, 0xBE, 0xDE, 0x6E, 0x2A, 0xE8, 0x1C, 0x0D, 0xD4, 0xC7, 0xA5, 0x2B, \
+0x6A, 0x7B, 0x27, 0xFE, 0x67, 0xD9, 0xE3, 0xD0, 0x49, 0xA7, 0xFB, 0xC2, 0x3A, 0x9A, 0xEF, 0xD8, 0x18, 0x88, 0xD7, 0xE7, \
+0x0B, 0xD5, 0xC5, 0xE4, 0x4D, 0x47, 0x37, 0x8B, 0x2F, 0x25, 0x13, 0x63, 0xB2, 0x2C, 0xA8, 0x6A, 0x97, 0x76, 0x2E, 0x62, \
+0xDB, 0x60, 0xE5, 0x41, 0x5C, 0xA6, 0xEB, 0xF7, 0xE0, 0x75, 0xB1, 0x81, 0xE2, 0xE4
+
+/*
+// Command:                  RF_NOP
+// Description:              No Operation command.
+*/
+#define RF_NOP 0x00
+
+/*
+// Command:                  RF_WRITE_TX_FIFO_1
+// Description:              Writes data byte(s) to the TX FIFO.
+*/
+#define RF_WRITE_TX_FIFO_1 0x66, 0xA7, 0x21, 0xD2, 0x48, 0x82, 0x99, 0x8D, 0xF8, 0x17, 0x53, 0xCD, 0xC2, 0x21, 0x7C, 0x28, 0x90, 0x29, 0xB8, 0xAD, \
+0x89, 0x2A, 0xE6, 0x9A, 0xE4, 0x3E, 0xEE, 0x58, 0x4C, 0x61, 0xD5, 0xA0, 0x09, 0xBD, 0xD3, 0x28, 0xD9, 0x65, 0xAA, 0x11, \
+0x91, 0xC4, 0xD4, 0x4C, 0xA1, 0x4A, 0x55, 0x1E, 0x72, 0x56, 0x5C, 0x3A, 0xAB, 0xF5, 0xEA, 0x2E, 0x6C, 0x88, 0x7C, 0x9B, \
+0xA3, 0x9E, 0xA6, 0x3C, 0xA1, 0x4F, 0x46, 0x9C, 0x22, 0x80, 0xE4, 0xFF, 0xA3, 0x44, 0x73, 0x16, 0xA2, 0x8C, 0xC0, 0x38, \
+0xEB, 0xEE, 0x3A, 0x57, 0x9C, 0xBD, 0xEB, 0x52, 0x67, 0xBC, 0xF1, 0x15, 0xC8, 0x93, 0xBB, 0x57, 0xFC, 0xF8, 0x70, 0x9A, \
+0x88, 0x68, 0x62, 0x9C, 0xFA, 0x50, 0xD8, 0x95, 0x5A, 0xA6, 0x26, 0xA3
+
+/*
+// Command:                  RF_EZCONFIG_CHECK
+// Description:              Validates the EZConfig array was written correctly.
+*/
+#define RF_EZCONFIG_CHECK 0x19, 0x22, 0x5C
+
+/*
+// Command:                  RF_GPIO_PIN_CFG
+// Description:              Configures the GPIO pins.
+*/
+#define RF_GPIO_PIN_CFG 0x13, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00
+
+
+// AUTOMATICALLY GENERATED CODE! 
+// DO NOT EDIT/MODIFY BELOW THIS LINE!
+// --------------------------------------------
+
+#ifndef FIRMWARE_LOAD_COMPILE
+#define RADIO_CONFIGURATION_DATA_ARRAY { \
+        0x07, RF_POWER_UP, \
+        0x06, RF_INT_CTL_ENABLE_2, \
+        0x05, RF_INT_CTL_CHIP_ENABLE_1, \
+        0x08, RF_FRR_CTL_A_MODE_4, \
+        0x05, RF_EZCONFIG_XO_TUNE_1, \
+        0x72, RF_WRITE_TX_FIFO, \
+        0x01, RF_NOP, \
+        0x70, RF_WRITE_TX_FIFO_1, \
+        0x03, RF_EZCONFIG_CHECK, \
+        0x08, RF_GPIO_PIN_CFG, \
+        0x00 \
+ }
+#else
+#define RADIO_CONFIGURATION_DATA_ARRAY { 0 }
+#endif
+
+// DEFAULT VALUES FOR CONFIGURATION PARAMETERS
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT                     30000000L
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT                    0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT               0x10
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT        0x01
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT       0x1000
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT  		           {0x42, 0x55, 0x54, 0x54, 0x4F, 0x4E, 0x31} // BUTTON1 
+
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_INCLUDED                      0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH_SIZE                          0x00
+#define RADIO_CONFIGURATION_DATA_RADIO_PATCH                               {  }
+
+#ifndef RADIO_CONFIGURATION_DATA_ARRAY
+#error "This property must be defined!"
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ
+#define RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ          RADIO_CONFIGURATION_DATA_RADIO_XO_FREQ_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER
+#define RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER         RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH
+#define RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH    RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP
+#define RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP   RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET
+#define RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET  RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET_DEFAULT 
+#endif
+
+#ifndef RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD
+#define RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD         RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD_DEFAULT 
+#endif
+
+#define RADIO_CONFIGURATION_DATA { \
+                            Radio_Configuration_Data_Array,                            \
+                            RADIO_CONFIGURATION_DATA_CHANNEL_NUMBER,                   \
+                            RADIO_CONFIGURATION_DATA_RADIO_PACKET_LENGTH,              \
+                            RADIO_CONFIGURATION_DATA_RADIO_STATE_AFTER_POWER_UP,       \
+                            RADIO_CONFIGURATION_DATA_RADIO_DELAY_CNT_AFTER_RESET,      \
+                            RADIO_CONFIGURATION_DATA_CUSTOM_PAYLOAD                    \
+                            }
+
+#endif /* RADIO_CONFIG_H_ */

--- a/si4455_revb1_bidir_fixed_crc_pre10_sync4_pay8_433mhz.xml
+++ b/si4455_revb1_bidir_fixed_crc_pre10_sync4_pay8_433mhz.xml
@@ -1,0 +1,266 @@
+<?xml version="1.0" encoding="Windows-1252"?>
+<RCA_ProjectData ProjectName="Bidirectional packet" ChipType="Si4455" ChipRevision="B1" Version="3.2.11.0">
+  <DataItems>
+    <tbpFrequencyAndPower Type="System.Windows.Forms.TabPage">
+      <grbFequencyControl Type="System.Windows.Forms.GroupBox">
+        <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudChannelNumber">
+          <Value>0</Value>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudCenterFrequency">
+          <Value>433.00000</Value>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudChannelSpacing">
+          <Value>250</Value>
+        </DataItem>
+      </grbFequencyControl>
+      <grbCrystalControl Type="System.Windows.Forms.GroupBox">
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbSi4010Support">
+          <Checked>False</Checked>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbUseExternalTCXO">
+          <Checked>False</Checked>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudCrystalToleranceTX">
+          <Value>30</Value>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudCrystalToleranceRX">
+          <Value>30</Value>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudCrystalFrequency">
+          <Value>30</Value>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudCrystalCapBank">
+          <Value>82</Value>
+        </DataItem>
+      </grbCrystalControl>
+      <grbPowerAmplifierControl Type="System.Windows.Forms.GroupBox">
+        <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudPaPowerLevel">
+          <Value>79</Value>
+        </DataItem>
+      </grbPowerAmplifierControl>
+    </tbpFrequencyAndPower>
+    <tbpRfParameters Type="System.Windows.Forms.TabPage">
+      <grbInput Type="System.Windows.Forms.GroupBox">
+        <DataItem Type="System.Windows.Forms.RadioButton" Name="rdbRxBw">
+          <Checked>False</Checked>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.RadioButton" Name="rdbRxTxPpm">
+          <Checked>True</Checked>
+        </DataItem>
+      </grbInput>
+      <grbEzConfigOptions Type="System.Windows.Forms.GroupBox">
+        <pnlRecommendedSettingsBack Type="System.Windows.Forms.Panel">
+          <pnlRecommendedSettingsFront Type="System.Windows.Forms.Panel">
+            <DataItem Type="System.Windows.Forms.DataGridView" Name="dgvEzConfig" />
+          </pnlRecommendedSettingsFront>
+        </pnlRecommendedSettingsBack>
+      </grbEzConfigOptions>
+      <grbRfParameters Type="System.Windows.Forms.GroupBox">
+        <pnlCustomSettingsBack Type="System.Windows.Forms.Panel">
+          <pnlCustomSettingsFront Type="System.Windows.Forms.Panel">
+            <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbModulationType">
+              <SelectedIndex>1</SelectedIndex>
+            </DataItem>
+            <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudDataRate">
+              <Value>2.4</Value>
+            </DataItem>
+            <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudDeviation">
+              <Value>30</Value>
+            </DataItem>
+            <DataItem Type="NewWDS.Applications.App_Common.CustomContols.NumericUpDownExtended" Name="nudBandwidth">
+              <Value>114</Value>
+            </DataItem>
+            <DataItem Type="System.Windows.Forms.CheckBox" Name="chbManualRxBandwidth">
+              <Checked>False</Checked>
+            </DataItem>
+            <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudRssiThreshold">
+              <Value>79</Value>
+            </DataItem>
+          </pnlCustomSettingsFront>
+        </pnlCustomSettingsBack>
+      </grbRfParameters>
+    </tbpRfParameters>
+    <tbpPacketHandler Type="System.Windows.Forms.TabPage">
+      <pccPacketHandlerConfigurator Type="NewWDS.Applications.App_Common.PacketConfigControl.EZR2_PacketConfigControl">
+        <grbGeneralConfiguration Type="System.Windows.Forms.GroupBox">
+          <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudPacketRxThreshold">
+            <Value>48</Value>
+          </DataItem>
+          <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudPacketTxThreshold">
+            <Value>48</Value>
+          </DataItem>
+          <DataItem Type="System.Windows.Forms.CheckBox" Name="chbGeneralManchesterEncoding">
+            <Checked>True</Checked>
+          </DataItem>
+          <grbManchesterPattern Type="System.Windows.Forms.GroupBox">
+            <DataItem Type="System.Windows.Forms.RadioButton" Name="rdb0eqs01">
+              <Checked>False</Checked>
+            </DataItem>
+            <DataItem Type="System.Windows.Forms.RadioButton" Name="rdb0eqs10">
+              <Checked>True</Checked>
+            </DataItem>
+          </grbManchesterPattern>
+        </grbGeneralConfiguration>
+        <grbPayload Type="System.Windows.Forms.GroupBox">
+          <pnlPayloadBack Type="System.Windows.Forms.Panel">
+            <pnlPayloadFront Type="System.Windows.Forms.Panel">
+              <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudPayloadLength">
+                <Value>8</Value>
+              </DataItem>
+              <haiPayloadContent Type="NewWDS.Applications.App_Common.PacketConfigControl.HexAsciiInputControl">
+                <DataItem Type="System.Windows.Forms.RadioButton" Name="rdbASCII">
+                  <Checked>False</Checked>
+                </DataItem>
+                <DataItem Type="System.Windows.Forms.RadioButton" Name="rdbHEX">
+                  <Checked>True</Checked>
+                </DataItem>
+                <pnlInput Type="System.Windows.Forms.Panel">
+                  <DataItem Type="System.Windows.Forms.MaskedTextBox" Name="mtbInput">
+                    <Text>C5 C5 C5 C5 C5 C5 C5 C5</Text>
+                  </DataItem>
+                </pnlInput>
+              </haiPayloadContent>
+              <DataItem Type="System.Windows.Forms.CheckBox" Name="chbEnableVariablePacketLength">
+                <Checked>False</Checked>
+              </DataItem>
+              <DataItem Type="System.Windows.Forms.RadioButton" Name="rdbCrcHighBytesFirst">
+                <Checked>True</Checked>
+              </DataItem>
+              <DataItem Type="System.Windows.Forms.RadioButton" Name="rdbCrcLowBytesFirst">
+                <Checked>False</Checked>
+              </DataItem>
+              <DataItem Type="System.Windows.Forms.CheckBox" Name="chbPayloadCheckCRC">
+                <Checked>True</Checked>
+              </DataItem>
+              <DataItem Type="System.Windows.Forms.CheckBox" Name="chbPayloadTransmitCRC">
+                <Checked>True</Checked>
+              </DataItem>
+              <pnlCrcSeed Type="System.Windows.Forms.Panel">
+                <DataItem Type="System.Windows.Forms.RadioButton" Name="rdbCrcSeed1">
+                  <Checked>True</Checked>
+                </DataItem>
+                <DataItem Type="System.Windows.Forms.RadioButton" Name="rdbCrcSeed0">
+                  <Checked>False</Checked>
+                </DataItem>
+              </pnlCrcSeed>
+            </pnlPayloadFront>
+          </pnlPayloadBack>
+        </grbPayload>
+        <grbSyncWord Type="System.Windows.Forms.GroupBox">
+          <pnlSyncWordBack Type="System.Windows.Forms.Panel">
+            <pnlSyncWordFront Type="System.Windows.Forms.Panel">
+              <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudSyncWordLength">
+                <Value>4</Value>
+              </DataItem>
+              <DataItem Type="System.Windows.Forms.MaskedTextBox" Name="mtbSyncWord">
+                <Text>2D D4 D2 4D</Text>
+              </DataItem>
+            </pnlSyncWordFront>
+          </pnlSyncWordBack>
+        </grbSyncWord>
+        <grbPreamble Type="System.Windows.Forms.GroupBox">
+          <pnlPreambleBack Type="System.Windows.Forms.Panel">
+            <PnlPreambleFront Type="System.Windows.Forms.Panel">
+              <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbPreamblePattern">
+                <SelectedIndex>0</SelectedIndex>
+              </DataItem>
+              <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudPreambleTxLength">
+                <Value>10</Value>
+              </DataItem>
+              <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudPreambleRXThreshold">
+                <Value>20</Value>
+              </DataItem>
+            </PnlPreambleFront>
+          </pnlPreambleBack>
+        </grbPreamble>
+      </pccPacketHandlerConfigurator>
+    </tbpPacketHandler>
+    <tbpInterrupts Type="System.Windows.Forms.TabPage">
+      <grbColorDescrition Type="System.Windows.Forms.GroupBox" />
+      <grbChipInterrupt Type="System.Windows.Forms.GroupBox">
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbEnableChipInterrupt">
+          <Checked>True</Checked>
+        </DataItem>
+        <DataItem Type="NewWDS.Applications.App_Common.ByteStatusControl.ByteStatus" Name="bstChipInterruptStatus">
+          <Enabled>True</Enabled>
+          <Value>108</Value>
+        </DataItem>
+      </grbChipInterrupt>
+      <grbModemInterrupt Type="System.Windows.Forms.GroupBox">
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbEnableModemInterrupt">
+          <Checked>False</Checked>
+        </DataItem>
+        <DataItem Type="NewWDS.Applications.App_Common.ByteStatusControl.ByteStatus" Name="bstModemInterruptStatus">
+          <Enabled>False</Enabled>
+          <Value>0</Value>
+        </DataItem>
+      </grbModemInterrupt>
+      <grbPacketHandlerInterrupt Type="System.Windows.Forms.GroupBox">
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbEnablePacketHandlerInterrupt">
+          <Checked>True</Checked>
+        </DataItem>
+        <DataItem Type="NewWDS.Applications.App_Common.ByteStatusControl.ByteStatus" Name="bstPacketHandlerInterruptStatus">
+          <Enabled>True</Enabled>
+          <Value>56</Value>
+        </DataItem>
+      </grbPacketHandlerInterrupt>
+    </tbpInterrupts>
+    <tbpGPIO Type="System.Windows.Forms.TabPage">
+      <grbFastResponseRegisters Type="System.Windows.Forms.GroupBox">
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbFrrA">
+          <SelectedIndex>9</SelectedIndex>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbFrrC">
+          <SelectedIndex>6</SelectedIndex>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbFrrD">
+          <SelectedIndex>8</SelectedIndex>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbFrrB">
+          <SelectedIndex>4</SelectedIndex>
+        </DataItem>
+      </grbFastResponseRegisters>
+      <grbGPIO Type="System.Windows.Forms.GroupBox">
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbGpio0Pullup">
+          <Checked>False</Checked>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbGpio0">
+          <SelectedIndex>TRISTATE</SelectedIndex>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbGpio1Pullup">
+          <Checked>False</Checked>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbGpio1">
+          <SelectedIndex>TRISTATE</SelectedIndex>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbGpio2Pullup">
+          <Checked>False</Checked>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbGpio2">
+          <SelectedIndex>TRISTATE</SelectedIndex>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbGpio3Pullup">
+          <Checked>False</Checked>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbGpio3">
+          <SelectedIndex>TRISTATE</SelectedIndex>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbNirqPullup">
+          <Checked>False</Checked>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbNirq">
+          <SelectedIndex>DONOTHING</SelectedIndex>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbSdoPullup">
+          <Checked>False</Checked>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbSdo">
+          <SelectedIndex>DONOTHING</SelectedIndex>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbDriveStrength">
+          <SelectedIndex>0</SelectedIndex>
+        </DataItem>
+      </grbGPIO>
+    </tbpGPIO>
+  </DataItems>
+</RCA_ProjectData>

--- a/si4455_revb1_bidir_vl_crc_pre10_sync4_pay8_433mhz.xml
+++ b/si4455_revb1_bidir_vl_crc_pre10_sync4_pay8_433mhz.xml
@@ -1,0 +1,266 @@
+<?xml version="1.0" encoding="Windows-1252"?>
+<RCA_ProjectData ProjectName="Bidirectional packet" ChipType="Si4455" ChipRevision="B1" Version="3.2.11.0">
+  <DataItems>
+    <tbpFrequencyAndPower Type="System.Windows.Forms.TabPage">
+      <grbFequencyControl Type="System.Windows.Forms.GroupBox">
+        <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudChannelNumber">
+          <Value>0</Value>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudCenterFrequency">
+          <Value>433.00000</Value>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudChannelSpacing">
+          <Value>250</Value>
+        </DataItem>
+      </grbFequencyControl>
+      <grbCrystalControl Type="System.Windows.Forms.GroupBox">
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbSi4010Support">
+          <Checked>False</Checked>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbUseExternalTCXO">
+          <Checked>False</Checked>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudCrystalToleranceTX">
+          <Value>30</Value>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudCrystalToleranceRX">
+          <Value>30</Value>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudCrystalFrequency">
+          <Value>30</Value>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudCrystalCapBank">
+          <Value>82</Value>
+        </DataItem>
+      </grbCrystalControl>
+      <grbPowerAmplifierControl Type="System.Windows.Forms.GroupBox">
+        <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudPaPowerLevel">
+          <Value>79</Value>
+        </DataItem>
+      </grbPowerAmplifierControl>
+    </tbpFrequencyAndPower>
+    <tbpRfParameters Type="System.Windows.Forms.TabPage">
+      <grbInput Type="System.Windows.Forms.GroupBox">
+        <DataItem Type="System.Windows.Forms.RadioButton" Name="rdbRxBw">
+          <Checked>False</Checked>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.RadioButton" Name="rdbRxTxPpm">
+          <Checked>True</Checked>
+        </DataItem>
+      </grbInput>
+      <grbEzConfigOptions Type="System.Windows.Forms.GroupBox">
+        <pnlRecommendedSettingsBack Type="System.Windows.Forms.Panel">
+          <pnlRecommendedSettingsFront Type="System.Windows.Forms.Panel">
+            <DataItem Type="System.Windows.Forms.DataGridView" Name="dgvEzConfig" />
+          </pnlRecommendedSettingsFront>
+        </pnlRecommendedSettingsBack>
+      </grbEzConfigOptions>
+      <grbRfParameters Type="System.Windows.Forms.GroupBox">
+        <pnlCustomSettingsBack Type="System.Windows.Forms.Panel">
+          <pnlCustomSettingsFront Type="System.Windows.Forms.Panel">
+            <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbModulationType">
+              <SelectedIndex>1</SelectedIndex>
+            </DataItem>
+            <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudDataRate">
+              <Value>128</Value>
+            </DataItem>
+            <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudDeviation">
+              <Value>70</Value>
+            </DataItem>
+            <DataItem Type="NewWDS.Applications.App_Common.CustomContols.NumericUpDownExtended" Name="nudBandwidth">
+              <Value>305</Value>
+            </DataItem>
+            <DataItem Type="System.Windows.Forms.CheckBox" Name="chbManualRxBandwidth">
+              <Checked>False</Checked>
+            </DataItem>
+            <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudRssiThreshold">
+              <Value>79</Value>
+            </DataItem>
+          </pnlCustomSettingsFront>
+        </pnlCustomSettingsBack>
+      </grbRfParameters>
+    </tbpRfParameters>
+    <tbpPacketHandler Type="System.Windows.Forms.TabPage">
+      <pccPacketHandlerConfigurator Type="NewWDS.Applications.App_Common.PacketConfigControl.EZR2_PacketConfigControl">
+        <grbGeneralConfiguration Type="System.Windows.Forms.GroupBox">
+          <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudPacketRxThreshold">
+            <Value>48</Value>
+          </DataItem>
+          <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudPacketTxThreshold">
+            <Value>48</Value>
+          </DataItem>
+          <DataItem Type="System.Windows.Forms.CheckBox" Name="chbGeneralManchesterEncoding">
+            <Checked>True</Checked>
+          </DataItem>
+          <grbManchesterPattern Type="System.Windows.Forms.GroupBox">
+            <DataItem Type="System.Windows.Forms.RadioButton" Name="rdb0eqs01">
+              <Checked>False</Checked>
+            </DataItem>
+            <DataItem Type="System.Windows.Forms.RadioButton" Name="rdb0eqs10">
+              <Checked>True</Checked>
+            </DataItem>
+          </grbManchesterPattern>
+        </grbGeneralConfiguration>
+        <grbPayload Type="System.Windows.Forms.GroupBox">
+          <pnlPayloadBack Type="System.Windows.Forms.Panel">
+            <pnlPayloadFront Type="System.Windows.Forms.Panel">
+              <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudPayloadLength">
+                <Value>8</Value>
+              </DataItem>
+              <haiPayloadContent Type="NewWDS.Applications.App_Common.PacketConfigControl.HexAsciiInputControl">
+                <DataItem Type="System.Windows.Forms.RadioButton" Name="rdbASCII">
+                  <Checked>False</Checked>
+                </DataItem>
+                <DataItem Type="System.Windows.Forms.RadioButton" Name="rdbHEX">
+                  <Checked>True</Checked>
+                </DataItem>
+                <pnlInput Type="System.Windows.Forms.Panel">
+                  <DataItem Type="System.Windows.Forms.MaskedTextBox" Name="mtbInput">
+                    <Text>C5 C5 C5 C5 C5 C5 C5 C5</Text>
+                  </DataItem>
+                </pnlInput>
+              </haiPayloadContent>
+              <DataItem Type="System.Windows.Forms.CheckBox" Name="chbEnableVariablePacketLength">
+                <Checked>True</Checked>
+              </DataItem>
+              <DataItem Type="System.Windows.Forms.RadioButton" Name="rdbCrcHighBytesFirst">
+                <Checked>True</Checked>
+              </DataItem>
+              <DataItem Type="System.Windows.Forms.RadioButton" Name="rdbCrcLowBytesFirst">
+                <Checked>False</Checked>
+              </DataItem>
+              <DataItem Type="System.Windows.Forms.CheckBox" Name="chbPayloadCheckCRC">
+                <Checked>True</Checked>
+              </DataItem>
+              <DataItem Type="System.Windows.Forms.CheckBox" Name="chbPayloadTransmitCRC">
+                <Checked>True</Checked>
+              </DataItem>
+              <pnlCrcSeed Type="System.Windows.Forms.Panel">
+                <DataItem Type="System.Windows.Forms.RadioButton" Name="rdbCrcSeed1">
+                  <Checked>True</Checked>
+                </DataItem>
+                <DataItem Type="System.Windows.Forms.RadioButton" Name="rdbCrcSeed0">
+                  <Checked>False</Checked>
+                </DataItem>
+              </pnlCrcSeed>
+            </pnlPayloadFront>
+          </pnlPayloadBack>
+        </grbPayload>
+        <grbSyncWord Type="System.Windows.Forms.GroupBox">
+          <pnlSyncWordBack Type="System.Windows.Forms.Panel">
+            <pnlSyncWordFront Type="System.Windows.Forms.Panel">
+              <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudSyncWordLength">
+                <Value>4</Value>
+              </DataItem>
+              <DataItem Type="System.Windows.Forms.MaskedTextBox" Name="mtbSyncWord">
+                <Text>2D D4 D2 4D</Text>
+              </DataItem>
+            </pnlSyncWordFront>
+          </pnlSyncWordBack>
+        </grbSyncWord>
+        <grbPreamble Type="System.Windows.Forms.GroupBox">
+          <pnlPreambleBack Type="System.Windows.Forms.Panel">
+            <PnlPreambleFront Type="System.Windows.Forms.Panel">
+              <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbPreamblePattern">
+                <SelectedIndex>0</SelectedIndex>
+              </DataItem>
+              <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudPreambleTxLength">
+                <Value>10</Value>
+              </DataItem>
+              <DataItem Type="System.Windows.Forms.NumericUpDown" Name="nudPreambleRXThreshold">
+                <Value>20</Value>
+              </DataItem>
+            </PnlPreambleFront>
+          </pnlPreambleBack>
+        </grbPreamble>
+      </pccPacketHandlerConfigurator>
+    </tbpPacketHandler>
+    <tbpInterrupts Type="System.Windows.Forms.TabPage">
+      <grbColorDescrition Type="System.Windows.Forms.GroupBox" />
+      <grbChipInterrupt Type="System.Windows.Forms.GroupBox">
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbEnableChipInterrupt">
+          <Checked>True</Checked>
+        </DataItem>
+        <DataItem Type="NewWDS.Applications.App_Common.ByteStatusControl.ByteStatus" Name="bstChipInterruptStatus">
+          <Enabled>True</Enabled>
+          <Value>108</Value>
+        </DataItem>
+      </grbChipInterrupt>
+      <grbModemInterrupt Type="System.Windows.Forms.GroupBox">
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbEnableModemInterrupt">
+          <Checked>False</Checked>
+        </DataItem>
+        <DataItem Type="NewWDS.Applications.App_Common.ByteStatusControl.ByteStatus" Name="bstModemInterruptStatus">
+          <Enabled>False</Enabled>
+          <Value>0</Value>
+        </DataItem>
+      </grbModemInterrupt>
+      <grbPacketHandlerInterrupt Type="System.Windows.Forms.GroupBox">
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbEnablePacketHandlerInterrupt">
+          <Checked>True</Checked>
+        </DataItem>
+        <DataItem Type="NewWDS.Applications.App_Common.ByteStatusControl.ByteStatus" Name="bstPacketHandlerInterruptStatus">
+          <Enabled>True</Enabled>
+          <Value>56</Value>
+        </DataItem>
+      </grbPacketHandlerInterrupt>
+    </tbpInterrupts>
+    <tbpGPIO Type="System.Windows.Forms.TabPage">
+      <grbFastResponseRegisters Type="System.Windows.Forms.GroupBox">
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbFrrA">
+          <SelectedIndex>9</SelectedIndex>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbFrrC">
+          <SelectedIndex>6</SelectedIndex>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbFrrD">
+          <SelectedIndex>8</SelectedIndex>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbFrrB">
+          <SelectedIndex>4</SelectedIndex>
+        </DataItem>
+      </grbFastResponseRegisters>
+      <grbGPIO Type="System.Windows.Forms.GroupBox">
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbGpio0Pullup">
+          <Checked>False</Checked>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbGpio0">
+          <SelectedIndex>TRISTATE</SelectedIndex>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbGpio1Pullup">
+          <Checked>False</Checked>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbGpio1">
+          <SelectedIndex>TRISTATE</SelectedIndex>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbGpio2Pullup">
+          <Checked>False</Checked>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbGpio2">
+          <SelectedIndex>TRISTATE</SelectedIndex>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbGpio3Pullup">
+          <Checked>False</Checked>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbGpio3">
+          <SelectedIndex>TRISTATE</SelectedIndex>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbNirqPullup">
+          <Checked>False</Checked>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbNirq">
+          <SelectedIndex>DONOTHING</SelectedIndex>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.CheckBox" Name="chbSdoPullup">
+          <Checked>False</Checked>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbSdo">
+          <SelectedIndex>DONOTHING</SelectedIndex>
+        </DataItem>
+        <DataItem Type="System.Windows.Forms.ComboBox" Name="cbbDriveStrength">
+          <SelectedIndex>0</SelectedIndex>
+        </DataItem>
+      </grbGPIO>
+    </tbpGPIO>
+  </DataItems>
+</RCA_ProjectData>


### PR DESCRIPTION
As promised! Updates for 433MHz operation.
Files and readme changes
Added:-
 - XML and header files for 433 MHz in fixed and variable length operation
 - Support for a FREQ_433 define to use 433MHz mode
 - .gitignore added
 - README updated to reflect additional 433MHz testing, using 433MHz operation, and the SDI/MISO SDO/MOSI reversal issue on the Arduino Pro Mini